### PR TITLE
Update target frameworks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,12 +15,12 @@ jobs:
 #  build:
 #    runs-on: ubuntu-latest
 #    steps:
-#    - uses: actions/checkout@v1
+#    - uses: actions/checkout@v3
 #      
 #    - name: Setup Dotnet for use with actions
-#      uses: actions/setup-dotnet@v1
+#      uses: actions/setup-dotnet@v3
 #      with:
-#        dotnet-version: '5.0.x'
+#        dotnet-version: '8.0.x'
 #        
 #    - name: Build with dotnet
 #      run: dotnet build --configuration Release
@@ -29,12 +29,12 @@ jobs:
 #    needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
         
       - name: Setup Dotnet for use with actions
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: '5.0.x'
+          dotnet-version: '8.0.x'
         
       - name: Pack with dotnet
         run: dotnet pack --configuration Release

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -14,14 +14,9 @@
     <RepositoryType>git</RepositoryType>
     <IsPackable>false</IsPackable>
     <NoPackageAnalysis>true</NoPackageAnalysis>
-    <LangVersion>latest</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateFullPaths Condition="'$(TERM_PROGRAM)' == 'vscode'">true</GenerateFullPaths>
     <Nullable>enable</Nullable>
   </PropertyGroup>
-  
-  <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-*" PrivateAssets="All" Publish="false" />
-  </ItemGroup>
   
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <Authors>Ben McCallum, AutoGuru</Authors>
     <Product>kv-push</Product>

--- a/src/KeyValuePush.Redis/AutoGuru.KeyValuePush.Redis.csproj
+++ b/src/KeyValuePush.Redis/AutoGuru.KeyValuePush.Redis.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Version>1.0.1</Version>
+    <Version>2.0.0</Version>
     <Description>A dotnet global tool for pushing key-value data into redis.</Description>
     <Product>kv-push-redis</Product>
     <OutputType>Exe</OutputType>

--- a/src/KeyValuePush.Redis/AutoGuru.KeyValuePush.Redis.csproj
+++ b/src/KeyValuePush.Redis/AutoGuru.KeyValuePush.Redis.csproj
@@ -10,16 +10,12 @@
     <ToolCommandName>kv-push-redis</ToolCommandName>
     <ServerGarbageCollection>true</ServerGarbageCollection>
     <DebugType>embedded</DebugType>
-    <EmbedUntrackedSources>true</EmbedUntrackedSources>
   </PropertyGroup>
 
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="3.1.0" />
-    <PackageReference Include="StackExchange.Redis" Version="2.2.62" />
+    <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="4.1.0" />
+    <PackageReference Include="StackExchange.Redis" Version="2.7.17" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/KeyValuePush.Redis/RedisPusher.cs
+++ b/src/KeyValuePush.Redis/RedisPusher.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 
 namespace AutoGuru.KeyValuePush.Redis
 {
-    public class RedisPusher : IPusher, IDisposable
+    public sealed class RedisPusher : IPusher, IDisposable
     {
         private ConnectionMultiplexer? _connectionMultiplexer;
         private IDatabase? _db;

--- a/src/KeyValuePush/AutoGuru.KeyValuePush.csproj
+++ b/src/KeyValuePush/AutoGuru.KeyValuePush.csproj
@@ -1,7 +1,3 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-*" PrivateAssets="All" Publish="false" />
-  </ItemGroup>
-
 </Project>


### PR DESCRIPTION
Updates this command line tool to latest dotnet frameworks. 

Also:
* Bumps deps
* Handles some warnings
* Drops SourceLink dep as that seems to be built-in to .NET 8 by default now ([source](https://github.com/dotnet/sourcelink)). 